### PR TITLE
Upgrade to Rust 2021 and Bump Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ authors = ["paul@colomiets.name"]
 combine = "3.5.1"
 failure = "0.1.1"
 matches = "0.1.6"
-strsim = { version="0.7.0", optional=true }
+strsim = { version= "0.10.0", optional=true }
 
 [features]
 default = ["fuzzy_errors"]
 fuzzy_errors = ["strsim"]
 
 [dev-dependencies]
-pretty_assertions = "0.5.1"
+pretty_assertions = "1.3.0"
 regex = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2021"
 name = "nginx-config"
 description = """
     A parser, AST and formatter for nginx configuration files.

--- a/src/access.rs
+++ b/src/access.rs
@@ -5,9 +5,9 @@ use combine::{choice};
 use combine::error::StreamError;
 use combine::easy::Error;
 
-use ast::{Item, Source};
-use helpers::{semi, ident, string};
-use tokenizer::{TokenStream, Token};
+use crate::ast::{Item, Source};
+use crate::helpers::{semi, ident, string};
+use crate::tokenizer::{TokenStream, Token};
 
 
 fn parse_source<'a>(val: Token<'a>)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -4,9 +4,10 @@
 use std::path::PathBuf;
 use std::net::{SocketAddr, IpAddr};
 
-pub use value::{Value};
-use position::Pos;
-use visitors::{DirectiveIter};
+pub use crate::value::{Value};
+use crate::position::Pos;
+use crate::visitors::{DirectiveIter};
+use crate::ast;
 
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -724,13 +725,13 @@ impl Item {
             Expires(self::Expires { ref mut value, .. }) => f(value),
             Root(ref mut v) => f(v),
             Alias(ref mut v) => f(v),
-            ErrorPage(::ast::ErrorPage { ref mut uri, .. }) => f(uri),
+            ErrorPage(ast::ErrorPage { ref mut uri, .. }) => f(uri),
             DefaultType(ref mut v) => f(v),
             ErrorLog { ref mut file, .. } => f(file),
             Rewrite(ref mut rw) => f(&mut rw.replacement),
-            Return(::ast::Return::Redirect { ref mut url, .. }) => f(url),
-            Return(::ast::Return::Text { text: Some(ref mut t), .. }) => f(t),
-            Return(::ast::Return::Text { text: None, .. }) => {},
+            Return(ast::Return::Redirect { ref mut url, .. }) => f(url),
+            Return(ast::Return::Text { text: Some(ref mut t), .. }) => f(t),
+            Return(ast::Return::Text { text: None, .. }) => {},
             If(self::If { ref mut condition, .. }) => {
                 use self::IfCondition::*;
                 match condition {
@@ -776,7 +777,7 @@ impl Item {
             SslCertificateKey(ref mut v) => f(v),
             ServerName(_) => {},
             Set { ref mut value, .. } => f(value),
-            Map(::ast::Map {
+            Map(ast::Map {
                 ref mut expression,
                 ref mut default,
                 ref mut patterns,
@@ -807,8 +808,8 @@ impl Item {
             Allow(..) => {},
             Deny(..) => {},
             // log module
-            AccessLog(::ast::AccessLog::Off) => {},
-            AccessLog(::ast::AccessLog::On(ref mut lg)) => {
+            AccessLog(ast::AccessLog::Off) => {},
+            AccessLog(ast::AccessLog::On(ref mut lg)) => {
                 f(&mut lg.path);
                 lg.condition.as_mut().map(f);
             },

--- a/src/core.rs
+++ b/src/core.rs
@@ -5,18 +5,18 @@ use combine::{choice, optional};
 use combine::error::StreamError;
 use combine::easy::Error;
 
-use ast::{self, Item};
-use grammar::{value, bool, block, Code};
-use helpers::{semi, ident, string, prefix};
-use tokenizer::{TokenStream, Token};
-use value::Value;
+use crate::ast::{self, Item};
+use crate::grammar::{value, bool, block, Code};
+use crate::helpers::{semi, ident, string, prefix};
+use crate::tokenizer::{TokenStream, Token};
+use crate::value::Value;
 
 
 fn error_page<'a>()
     -> impl Parser<Output=Item, Input=TokenStream<'a>>
 {
-    use ast::ErrorPageResponse;
-    use value::Item::*;
+    use crate::ast::ErrorPageResponse;
+    use crate::value::Item::*;
 
     fn lit<'a, 'x>(val: &'a Value) -> Result<&'a str, Error<Token<'x>, Token<'x>>> {
         if val.data.is_empty() {
@@ -68,7 +68,7 @@ fn error_page<'a>()
             codes.push(Code::parse(lit(&code)?)?.as_code());
         }
 
-        Ok(Item::ErrorPage(::ast::ErrorPage {
+        Ok(Item::ErrorPage(ast::ErrorPage {
             codes,
             response_code,
             uri,

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,8 +1,8 @@
-use ast;
+use crate::ast;
 use std::fmt;
-use format::{Displayable, Formatter, Style};
+use crate::format::{Displayable, Formatter, Style};
 
-use value;
+use crate::value;
 
 impl Displayable for ast::Main {
     fn display(&self, f: &mut Formatter) {
@@ -332,7 +332,7 @@ impl Displayable for ast::Item {
                 }
                 f.end();
             }
-            Expires(::ast::Expires { modified, ref value }) => {
+            Expires(ast::Expires { modified, ref value }) => {
                 f.indent();
                 f.write("expires ");
                 if modified {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use combine::easy::{Errors, Error};
 
-use tokenizer::Token;
-use position::Pos;
+use crate::tokenizer::Token;
+use crate::position::Pos;
 
 pub type InternalError<'a> = Errors<Token<'a>, Token<'a>, Pos>;
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -89,9 +89,9 @@ pub fn map<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
     .and(string().and_then(|t| {
         let ch1 = t.value.chars().nth(0).unwrap_or(' ');
         let ch2 = t.value.chars().nth(1).unwrap_or(' ');
-        if ch1 == '$' && matches!(ch2, 'a'...'z' | 'A'...'Z' | '_') &&
+        if ch1 == '$' && matches!(ch2, 'a'..='z' | 'A'..='Z' | '_') &&
             t.value[2..].chars()
-            .all(|x| matches!(x, 'a'...'z' | 'A'...'Z' | '0'...'9' | '_'))
+            .all(|x| matches!(x, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_'))
         {
             Ok(t.value[1..].to_string())
         } else {
@@ -202,7 +202,7 @@ impl Code {
         let code = code_str.parse::<u32>()?;
         match code {
             301 | 302 | 303 | 307 | 308 => Ok(Code::Redirect(code)),
-            200...599 => Ok(Code::Normal(code)),
+            200..=599 => Ok(Code::Normal(code)),
             _ => return Err(Error::unexpected_message(
                 format!("invalid response code {}", code))),
         }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -4,21 +4,21 @@ use combine::combinator::{opaque, no_partial, FnOpaque};
 use combine::error::StreamError;
 use combine::easy::Error;
 
-use ast::{self, Main, Directive, Item};
-use error::ParseError;
-use helpers::{semi, ident, text, string};
-use position::Pos;
-use tokenizer::{TokenStream, Token};
-use value::Value;
+use crate::ast::{self, Main, Directive, Item};
+use crate::error::ParseError;
+use crate::helpers::{semi, ident, text, string};
+use crate::position::Pos;
+use crate::tokenizer::{TokenStream, Token};
+use crate::value::Value;
 
-use access;
-use core;
-use gzip;
-use headers;
-use proxy;
-use rewrite;
-use log;
-use real_ip;
+use crate::access;
+use crate::core;
+use crate::gzip;
+use crate::headers;
+use crate::proxy;
+use crate::rewrite;
+use crate::log;
+use crate::real_ip;
 
 
 pub enum Code {
@@ -75,8 +75,8 @@ pub fn server_name<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
 
 
 pub fn map<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
-    use tokenizer::Kind::{BlockStart, BlockEnd};
-    use helpers::kind;
+    use crate::tokenizer::Kind::{BlockStart, BlockEnd};
+    use crate::helpers::kind;
     enum Tok {
         Hostnames,
         Volatile,
@@ -108,7 +108,7 @@ pub fn map<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
     )).skip(semi())))
     .skip(kind(BlockEnd))
     .map(|((expression, variable), vec): ((_, _), Vec<Tok>)| {
-        let mut res = ::ast::Map {
+        let mut res = ast::Map {
             variable, expression,
             default: None,
             hostnames: false,
@@ -155,8 +155,8 @@ pub fn map<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
 pub fn block<'a>()
     -> FnOpaque<TokenStream<'a>, ((Pos, Pos), Vec<Directive>)>
 {
-    use tokenizer::Kind::{BlockStart, BlockEnd};
-    use helpers::kind;
+    use crate::tokenizer::Kind::{BlockStart, BlockEnd};
+    use crate::helpers::kind;
     opaque(|f| {
         f(&mut no_partial((
                 position(),
@@ -217,9 +217,9 @@ impl Code {
 
 
 pub fn try_files<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
-    use ast::TryFilesLastOption::*;
-    use ast::Item::TryFiles;
-    use value::Item::*;
+    use crate::ast::TryFilesLastOption::*;
+    use crate::ast::Item::TryFiles;
+    use crate::value::Item::*;
 
     ident("try_files")
     .with(many1(value()))
@@ -235,7 +235,7 @@ pub fn try_files<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
             }
             _ => Uri(last.clone()),
         };
-        Ok(TryFiles(::ast::TryFiles {
+        Ok(TryFiles(ast::TryFiles {
             options: v,
             last_option: last,
         }))
@@ -244,7 +244,7 @@ pub fn try_files<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
 
 
 pub fn openresty<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
-    use ast::Item::*;
+    use crate::ast::Item::*;
     choice((
         ident("rewrite_by_lua_file").with(value()).skip(semi())
             .map(Item::RewriteByLuaFile),

--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -1,13 +1,13 @@
 use combine::{many1, Parser};
 use combine::{choice};
 
-use ast::{Item};
-use grammar::bool;
-use helpers::{semi, ident};
-use tokenizer::TokenStream;
+use crate::ast::{Item};
+use crate::grammar::bool;
+use crate::helpers::{semi, ident};
+use crate::tokenizer::TokenStream;
 
 pub fn gzip_static<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
-    use ast::GzipStatic::*;
+    use crate::ast::GzipStatic::*;
     ident("gzip_static").with(choice((
         ident("on").map(|_| On),
         ident("off").map(|_| Off),
@@ -18,7 +18,7 @@ pub fn gzip_static<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
 }
 
 pub fn gzip_proxied<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
-    use ast::GzipProxied::*;
+    use crate::ast::GzipProxied::*;
     ident("gzip_proxied").with(many1(choice((
         ident("off").map(|_| Off),
         ident("expired").map(|_| Expired),

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,10 +1,10 @@
 use combine::{Parser, optional};
 use combine::{choice};
 
-use ast::{self, Item};
-use grammar::{value};
-use helpers::{semi, ident};
-use tokenizer::{TokenStream};
+use crate::ast::{self, Item};
+use crate::grammar::{value};
+use crate::helpers::{semi, ident};
+use crate::tokenizer::{TokenStream};
 
 fn add_header<'a>()
     -> impl Parser<Output=Item, Input=TokenStream<'a>>

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -4,8 +4,8 @@ use combine::{Parser, ConsumedResult, satisfy, StreamOnce};
 use combine::error::{Tracked};
 use combine::stream::easy::{Error, Errors, Info};
 
-use tokenizer::{TokenStream, Kind, Token};
-use position::Pos;
+use crate::tokenizer::{TokenStream, Kind, Token};
+use crate::position::Pos;
 
 
 #[derive(Debug, Clone)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -3,11 +3,11 @@ use combine::{choice, optional, position};
 use combine::error::StreamError;
 use combine::easy::Error;
 
-use ast::{self, Item};
-use grammar::{value};
-use helpers::{semi, ident, string};
-use tokenizer::{TokenStream};
-use value::Value;
+use crate::ast::{self, Item};
+use crate::grammar::{value};
+use crate::helpers::{semi, ident, string};
+use crate::tokenizer::{TokenStream};
+use crate::value::Value;
 
 
 fn access_log<'a>()

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3,10 +3,10 @@ use combine::{choice, many1};
 use combine::error::StreamError;
 use combine::easy::Error;
 
-use ast::{self, Item};
-use helpers::{semi, ident, string};
-use tokenizer::TokenStream;
-use grammar::{value, bool, Code};
+use crate::ast::{self, Item};
+use crate::helpers::{semi, ident, string};
+use crate::tokenizer::TokenStream;
+use crate::grammar::{value, bool, Code};
 
 
 pub fn directives<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
@@ -25,8 +25,8 @@ pub fn directives<'a>() -> impl Parser<Output=Item, Input=TokenStream<'a>> {
         ident("proxy_cache_valid")
             .with(many1(value()))
             .and_then(|mut v: Vec<_>| {
-                use ast::ProxyCacheValid::*;
-                use value::Item::*;
+                use crate::ast::ProxyCacheValid::*;
+                use crate::value::Item::*;
                 let time = v.pop().unwrap();
                 if v.len() == 0 {
                     return Ok(Normal(time));

--- a/src/real_ip.rs
+++ b/src/real_ip.rs
@@ -4,10 +4,10 @@ use combine::{choice, Parser};
 use combine::error::StreamError;
 use combine::easy::Error;
 
-use ast::{Item, RealIpFrom};
-use grammar::{value, bool};
-use helpers::{semi, ident, string};
-use tokenizer::{TokenStream, Token};
+use crate::ast::{Item, RealIpFrom};
+use crate::grammar::{value, bool};
+use crate::helpers::{semi, ident, string};
+use crate::tokenizer::{TokenStream, Token};
 
 
 fn parse_source<'a>(val: Token<'a>)

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -41,9 +41,9 @@ fn set<'a>()
     .with(string().and_then(|t| {
         let ch1 = t.value.chars().nth(0).unwrap_or(' ');
         let ch2 = t.value.chars().nth(1).unwrap_or(' ');
-        if ch1 == '$' && matches!(ch2, 'a'...'z' | 'A'...'Z' | '_') &&
+        if ch1 == '$' && matches!(ch2, 'a'..='z' | 'A'..='Z' | '_') &&
             t.value[2..].chars()
-            .all(|x| matches!(x, 'a'...'z' | 'A'...'Z' | '0'...'9' | '_'))
+            .all(|x| matches!(x, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_'))
         {
             Ok(t.value[1..].to_string())
         } else {

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -3,19 +3,19 @@ use combine::{choice, optional, many1, position};
 use combine::error::StreamError;
 use combine::easy::Error;
 
-use ast::{self, Item};
-use grammar::{value, block, Code};
-use helpers::{semi, ident, string};
-use position::Pos;
-use tokenizer::{TokenStream, Token};
-use value::{Value};
+use crate::ast::{self, Item};
+use crate::grammar::{value, block, Code};
+use crate::helpers::{semi, ident, string};
+use crate::position::Pos;
+use crate::tokenizer::{TokenStream, Token};
+use crate::value::{Value};
 
 
 fn rewrite<'a>()
     -> impl Parser<Output=Item, Input=TokenStream<'a>>
 {
-    use ast::RewriteFlag::*;
-    use ast::Item::Rewrite;
+    use crate::ast::RewriteFlag::*;
+    use crate::ast::Item::Rewrite;
 
     ident("rewrite")
     .with(string())
@@ -58,8 +58,8 @@ fn set<'a>()
 fn return_directive<'a>()
     -> impl Parser<Output=Item, Input=TokenStream<'a>>
 {
-    use ast::Return::*;
-    use value::Item::*;
+    use crate::ast::Return::*;
+    use crate::value::Item::*;
 
     fn lit<'a, 'x>(val: &'a Value) -> Result<&'a str, Error<Token<'x>, Token<'x>>> {
         if val.data.is_empty() {
@@ -179,7 +179,7 @@ fn parse_unary<'a>(mut v: Vec<&str>, position: Pos)
 fn parse_binary<'a>(mut v: Vec<&str>, position: Pos)
     -> Result<ast::IfCondition, Error<Token<'a>, Token<'a>>>
 {
-    use ast::IfCondition::*;
+    use crate::ast::IfCondition::*;
 
     let left = Value::parse_str(position, v.remove(0))?;
     if v.len() == 0 {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -5,7 +5,7 @@ use combine::error::{StreamError};
 use combine::stream::{Resetable};
 use combine::easy::{Error, Errors};
 
-use position::Pos;
+use crate::position::Pos;
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/value.rs
+++ b/src/value.rs
@@ -73,7 +73,7 @@ impl Value {
                         '{' => {
                             while let Some(&(_, c)) = chiter.peek() {
                                 match c {
-                                    'a'...'z' | 'A'...'Z' | '_' | '0'...'9'
+                                    'a'..='z' | 'A'..='Z' | '_' | '0'..='9'
                                     => chiter.next(),
                                     '}' => break,
                                     _ => {
@@ -87,10 +87,10 @@ impl Value {
                                 value[vstart+1..now].to_string()));
                             cur_slice = now+1;
                         }
-                        'a'...'z' | 'A'...'Z' | '_' | '0'...'9' => {
+                        'a'..='z' | 'A'..='Z' | '_' | '0'..='9' => {
                             while let Some(&(_, c)) = chiter.peek() {
                                 match c {
-                                    'a'...'z' | 'A'...'Z' | '_' | '0'...'9'
+                                    'a'..='z' | 'A'..='Z' | '_' | '0'..='9'
                                     => chiter.next(),
                                     _ => break,
                                 };
@@ -159,10 +159,10 @@ impl Value {
                         '{' => {
                             unimplemented!();
                         }
-                        'a'...'z' | 'A'...'Z' | '_' | '0'...'9' => {
+                        'a'..='z' | 'A'..='Z' | '_' | '0'..='9' => {
                             while let Some(&(_, c)) = chiter.peek() {
                                 match c {
-                                    'a'...'z' | 'A'...'Z' | '_' | '0'...'9'
+                                    'a'..='z' | 'A'..='Z' | '_' | '0'..='9'
                                     => chiter.next(),
                                     _ => break,
                                 };

--- a/src/value.rs
+++ b/src/value.rs
@@ -4,9 +4,9 @@ use std::str::FromStr;
 use combine::easy::Error;
 use combine::error::StreamError;
 
-use format::{Displayable, Formatter};
-use position::Pos;
-use tokenizer::Token;
+use crate::format::{Displayable, Formatter};
+use crate::position::Pos;
+use crate::tokenizer::Token;
 
 /// Generic string value
 ///

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -1,8 +1,8 @@
 //! Various visitors for working with AST
 use std::collections::VecDeque;
 
-use ast::Directive;
-use value::Value;
+use crate::ast::Directive;
+use crate::value::Value;
 
 
 /// A deep iterator over all directives in configuration file or a part of it


### PR DESCRIPTION
The commits associated with this PR do two things:

* Modify the Rust syntax to be compatible with Rust 2021
* Upgrade libraries that do not require code changes

As a side note, is this project still maintained?